### PR TITLE
Fix some operators in pysnark.runtime

### DIFF
--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -258,7 +258,12 @@ class LinComb:
             other = other * LinComb.ONE
 
         # Handle powers of two
-        # Do check using value to prevent calling __bool__. No need to output as constraint
+        # Do check using value to prevent calling __bool__
+        # If statement logic isn't outputted in constraint. May need rework
+        if other.value == 0:
+            return ZeroDivisionError
+        if other.value == 1:
+            return LinComb.ZERO
         if other.value & (other.value - 1)==0:
             return LinComb.from_bits(self.to_bits()[:other.value.bit_length()-1])
         
@@ -412,6 +417,9 @@ class LinComb:
         
     @classmethod
     def from_bits(cls, bits):
+        if bits == []:
+            return LinComb.ZERO
+
         return sum([biti*(1<<i) for (i,biti) in enumerate(bits)])
         
     """

--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -252,9 +252,13 @@ class LinComb:
         return self.__divmod__(other)[0]
 
     def __mod__(self, other):
-        if other&(other-1)==0:
-            # this is faster for powers of two
-            return LinComb.from_bits(self.to_bits()[:other.bit_length()-1])
+        if is_base_value(other):
+            other = other * LinComb.ONE
+
+        # Handle powers of two
+        # Do check using value to prevent calling __bool__. No need to output as constraint
+        if other.value & (other.value - 1)==0:
+            return LinComb.from_bits(self.to_bits()[:other.value.bit_length()-1])
         
         return self.__divmod__(other)[1]
         

--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -249,7 +249,9 @@ class LinComb:
          
     def __floordiv__(self, other):
         """ Division with rounding """
-        return self.__divmod__(other)[0]
+        res = self.__divmod__(other)
+        if res is NotImplemented: return NotImplemented
+        return res[0]
 
     def __mod__(self, other):
         if is_base_value(other):
@@ -260,7 +262,9 @@ class LinComb:
         if other.value & (other.value - 1)==0:
             return LinComb.from_bits(self.to_bits()[:other.value.bit_length()-1])
         
-        return self.__divmod__(other)[1]
+        res = self.__divmod__(other)
+        if res is NotImplemented: return NotImplemented
+        return res[1]
         
     def __divmod__(self, divisor):
         """ Division by public value """


### PR DESCRIPTION
* Fixed modulus for powers of 2. Previously, doing mods would cause a crash
* Bubble up NotImplemented errors when needed