### PR TITLE
Bugfix: Constraint for check_positive is not sufficient

### DIFF
--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -616,8 +616,8 @@ class LinComb:
         add_constraint(2 * ret, self, self + LinComb.from_bits(bits))
 
         # We need an additional constraint for ensuring self == 0 => ret = 1
-        w = PrivVal(1 if self.value == 0 else (1 - ret.value)/self.value)
-        add_constraint(self, w, 1 - ret)
+        w = PrivVal(1 if self.value == 0 else (1 - ret.lc.value) * backend.fieldinverse(self.value))
+        add_constraint_unsafe(self, w, 1 - ret)
         
         return ret
             

--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -602,7 +602,7 @@ class LinComb:
 
         if is_guard() and self.value.bit_length() <= bits:
             ret = PrivValBool(1 if self.value >= 0 else 0)
-            abs = self.value if self.value >= 0 else -self.value
+            abs = self.value if self.value >= 0 else -self.value - 1
 
             bits = [PrivValBool((abs & (1 << ix)) >> ix) for ix in range(bits)]
         elif ignore_errors():
@@ -613,12 +613,7 @@ class LinComb:
         
         # If ret == 1, then requires that 2 * self = self + sum, so sum = self
         # If ret == 0, this requires that 0 = self + sum, so sum = -self
-        add_constraint(2 * ret, self, self + LinComb.from_bits(bits))
-
-        # We need an additional constraint for ensuring self == 0 => ret = 1
-        w = PrivVal(1 if self.value == 0 else (1 - ret.lc.value) * backend.fieldinverse(self.value))
-        add_constraint_unsafe(self, w, 1 - ret)
-        
+        add_constraint(2 * ret, self, self + LinComb.from_bits(bits) + (1-ret))
         return ret
             
     def assert_positive(self, bits=None, err=None):

--- a/pysnark/runtime.py
+++ b/pysnark/runtime.py
@@ -614,6 +614,10 @@ class LinComb:
         # If ret == 1, then requires that 2 * self = self + sum, so sum = self
         # If ret == 0, this requires that 0 = self + sum, so sum = -self
         add_constraint(2 * ret, self, self + LinComb.from_bits(bits))
+
+        # We need an additional constraint for ensuring self == 0 => ret = 1
+        w = PrivVal(1 if self.value == 0 else (1 - ret.value)/self.value)
+        add_constraint(self, w, 1 - ret)
         
         return ret
             


### PR DESCRIPTION
The `__ge__` comparison uses `check_positive` to generate a constraint for proving a >= b. However, the constraint in `check_positive` is not sufficient, as for the case a = b, the return value can both be 1 and 0 and still satisfy the constraint. Therefore, a malicous prover could illegitimately claim a wrong statement, such as 1 < 1 (see example below).

The constraint for check positive is `2*ret*val = val + abs(val)`, which evaluates to 0 = 0, for val = 0, regardless of ret.

By adding another constraint in check_positive ensuring ret to be 1 if the value is 0, this problem can be mitigated:
`val*w = 1 - ret`. w is a new Private Value added to the problem.

Minimal Example:
1.) run generator:
```
import pysnark.runtime
from pysnark.runtime import snark

pysnark.runtime.autoprove = False
pysnark.runtime.operation = "keygen"

@snark
def compare_greater_equal(a, b):
    return a >= b

print(f"1 is greater or equal than 1: {compare_greater_equal(1, 1)}")

```
2.) run cheating prover:
```
import pysnark.runtime

pysnark.runtime.autoprove = False
pysnark.runtime.operation = "prove"


class LinCombCheat(pysnark.runtime.LinComb):
    def check_positive(self, bits=None):
        """
        Checks if a LinComb is a positive bitlength-bit integer
        Costs bitlength + 2 constraints
        """
        from pysnark.boolean import PrivValBool

        if bits is None:
            bits = pysnark.runtime.bitlength

        if pysnark.runtime.is_guard() and self.value.bit_length() <= bits:
            #ret = PrivValBool(1 if self.value >= 0 else 0)
            ret = PrivValBool(0) # The prover can cheat by assigning wrong return value, if self is 0
            abs = self.value if self.value >= 0 else -self.value

            bits = [PrivValBool((abs & (1 << ix)) >> ix) for ix in range(bits)]
        elif pysnark.runtime.ignore_errors():
            ret = PrivValBool(0)
            bits = [PrivValBool(0) for _ in range(bits)]
        else:
            raise ValueError(str(self.value) + " is not a " + str(bits) + "-bit integer")

        # If ret == 1, then requires that 2 * self = self + sum, so sum = self
        # If ret == 0, this requires that 0 = self + sum, so sum = -self
        pysnark.runtime.add_constraint(2 * ret, self, self + pysnark.runtime.LinComb.from_bits(bits))

        return ret

    def __ge__(self, other):
        return (self-other).check_positive()

    def __add__(self, other):
        """
        Adds a LinComb with an integer or another LinComb
        Costs 0 constraints
        """
        if isinstance(other, int):
            return self + pysnark.runtime.ConstVal(other)
        if isinstance(other, pysnark.runtime.LinComb):
            return LinCombCheat(self.value + other.value, self.lc + other.lc)
        return NotImplemented

    def __sub__(self, other):
        """
        Subtracts an integer or another LinComb from a LinComb
        Costs 0 constraints
        """
        return self + (-other)


def compare_greater_equal(a, b):
    return a >= b

print(f"1 is greater or equal than 1: {compare_greater_equal(LinCombCheat(1, pysnark.runtime.backend.pubval(1)), pysnark.runtime.PubVal(1)).val()}")
```
3.) Verifier accepts wrong statement: (1 >= 1) == false
```
import pysnark.runtime

pysnark.runtime.autoprove = False
pysnark.runtime.operation = "verify"
```
